### PR TITLE
Fix bug in setfreq

### DIFF
--- a/src/WEMOS_Motor.cpp
+++ b/src/WEMOS_Motor.cpp
@@ -60,7 +60,7 @@ freq:
 void Motor::setfreq(uint32_t freq)
 {
 	Wire.beginTransmission(_address);
-	Wire.write(((byte)(freq >> 16)) & (byte)0x0f);
+	Wire.write(((byte)(freq >> 24)) & (byte)0x0f);
 	Wire.write((byte)(freq >> 16));
 	Wire.write((byte)(freq >> 8));
 	Wire.write((byte)freq);


### PR DESCRIPTION
The high byte of the frequency is reached by shifting by 24, not 16.  See https://github.com/pbugalski/wemos_motor_shield/blob/master/src/user_i2c.c#L24 .